### PR TITLE
fixed issue with SQL syntax

### DIFF
--- a/src/main/java/com/artillexstudios/axinventoryrestore/database/impl/Base.java
+++ b/src/main/java/com/artillexstudios/axinventoryrestore/database/impl/Base.java
@@ -100,7 +100,7 @@ public abstract class Base implements Database {
             log.error("An unexpected error occurred while creating axir_worlds table!", exception);
         }
 
-        final String CREATE_INDEX1 = "CREATE TABLE IF NOT EXISTS axir_worlds (id INT NOT NULL AUTO_INCREMENT, name VARCHAR(768) NOT NULL, PRIMARY KEY (id), UNIQUE (name));";
+        final String CREATE_INDEX1 = "ALTER axir_backups table_name ADD INDEX (userId);";
 
         try (Connection conn = getConnection(); PreparedStatement stmt = conn.prepareStatement(CREATE_INDEX1)) {
             stmt.executeUpdate();

--- a/src/main/java/com/artillexstudios/axinventoryrestore/database/impl/Base.java
+++ b/src/main/java/com/artillexstudios/axinventoryrestore/database/impl/Base.java
@@ -100,7 +100,7 @@ public abstract class Base implements Database {
             log.error("An unexpected error occurred while creating axir_worlds table!", exception);
         }
 
-        final String CREATE_INDEX1 = "CREATE INDEX IF NOT EXISTS idx_user ON axir_backups (userId);";
+        final String CREATE_INDEX1 = "CREATE TABLE IF NOT EXISTS axir_worlds (id INT NOT NULL AUTO_INCREMENT, name VARCHAR(768) NOT NULL, PRIMARY KEY (id), UNIQUE (name));";
 
         try (Connection conn = getConnection(); PreparedStatement stmt = conn.prepareStatement(CREATE_INDEX1)) {
             stmt.executeUpdate();


### PR DESCRIPTION
```
[16:51:36 ERROR]: [com.artillexstudios.axinventoryrestore.database.impl.Base] An unexpected error occurred while creating idx_user index!
java.sql.SQLSyntaxErrorException: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'IF NOT EXISTS idx_user ON axir_backups (userId)' at line 1
        at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:112) ~[mysql-connector-j-8.4.0.jar:8.4.0]
        at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:113) ~[mysql-connector-j-8.4.0.jar:8.4.0]
        at com.mysql.cj.jdbc.ClientPreparedStatement.executeInternal(ClientPreparedStatement.java:938) ~[mysql-connector-j-8.4.0.jar:8.4.0]
        at com.mysql.cj.jdbc.ClientPreparedStatement.executeUpdateInternal(ClientPreparedStatement.java:1106) ~[mysql-connector-j-8.4.0.jar:8.4.0]
        at com.mysql.cj.jdbc.ClientPreparedStatement.executeUpdateInternal(ClientPreparedStatement.java:1045) ~[mysql-connector-j-8.4.0.jar:8.4.0]
        at com.mysql.cj.jdbc.ClientPreparedStatement.executeLargeUpdate(ClientPreparedStatement.java:1369) ~[mysql-connector-j-8.4.0.jar:8.4.0]
        at com.mysql.cj.jdbc.ClientPreparedStatement.executeUpdate(ClientPreparedStatement.java:1030) ~[mysql-connector-j-8.4.0.jar:8.4.0]
        at AxInventoryRestore-3.2.2.jar/com.artillexstudios.axinventoryrestore.libs.hikari.hikari.pool.ProxyPreparedStatement.executeUpdate(ProxyPreparedStatement.java:61) ~[AxInventoryRestore-3.2.2.jar:?]
        at AxInventoryRestore-3.2.2.jar/com.artillexstudios.axinventoryrestore.libs.hikari.hikari.pool.HikariProxyPreparedStatement.executeUpdate(HikariProxyPreparedStatement.java) ~[AxInventoryRestore-3.2.2.jar:?]
        at AxInventoryRestore-3.2.2.jar/com.artillexstudios.axinventoryrestore.database.impl.Base.setup(Base.java:106) ~[AxInventoryRestore-3.2.2.jar:?]
        at AxInventoryRestore-3.2.2.jar/com.artillexstudios.axinventoryrestore.database.impl.MySQL.setup(MySQL.java:46) ~[AxInventoryRestore-3.2.2.jar:?]
        at AxInventoryRestore-3.2.2.jar/com.artillexstudios.axinventoryrestore.AxInventoryRestore.enable(AxInventoryRestore.java:105) ~[AxInventoryRestore-3.2.2.jar:?]
        at AxInventoryRestore-3.2.2.jar/com.artillexstudios.axinventoryrestore.libs.axapi.AxPlugin.onEnable(AxPlugin.java:111) ~[AxInventoryRestore-3.2.2.jar:?]
        at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:288) ~[paper-mojangapi-1.21-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.enablePlugin(PaperPluginInstanceManager.java:202) ~[purpur-1.21.jar:1.21-2275-82ccc76]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.enablePlugin(PaperPluginManagerImpl.java:109) ~[purpur-1.21.jar:1.21-2275-82ccc76]
        at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:520) ~[paper-mojangapi-1.21-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.CraftServer.enablePlugin(CraftServer.java:654) ~[purpur-1.21.jar:1.21-2275-82ccc76]
        at org.bukkit.craftbukkit.CraftServer.enablePlugins(CraftServer.java:603) ~[purpur-1.21.jar:1.21-2275-82ccc76]
        at net.minecraft.server.MinecraftServer.loadWorld0(MinecraftServer.java:756) ~[purpur-1.21.jar:1.21-2275-82ccc76]
        at net.minecraft.server.MinecraftServer.loadLevel(MinecraftServer.java:518) ~[purpur-1.21.jar:1.21-2275-82ccc76]
        at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:363) ~[purpur-1.21.jar:1.21-2275-82ccc76]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1229) ~[purpur-1.21.jar:1.21-2275-82ccc76]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:333) ~[purpur-1.21.jar:1.21-2275-82ccc76]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```
fixed src/main/java/com/artillexstudios/axinventoryrestore/database/impl/Base.java in order to get rid of this error