### PR TITLE
Updated discord.yml and Updated DiscordAddon.java

### DIFF
--- a/src/main/resources/discord.yml
+++ b/src/main/resources/discord.yml
@@ -131,9 +131,9 @@ bot-activity: "AxInventoryRestore"
 # where should the requests be sent?
 channel-id: ""
 
-# the permission needed to interact with a restore request on discord
-# list of permissions: https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/Permission.html
-required-permission: "ADMINISTRATOR"
+# the role needed to interact with a restore request on discord
+# it should look like this: required-role-id: "0000000000000000"
+required-role-id: "0000000000000000"
 
 create-thread: true
 thread-name: "Restore"


### PR DESCRIPTION
What I did:
1. Switched from permission-based to role-based access control:
   In discord.yml, I replaced the requirement for a specific permission with a requirement for a specific Discord role instead.

2. Fetched the required role ID from config:
   In DiscordAddon.java, I added the following line:
   `String requiredRoleId = DISCORD.getString("required-role-id");`
   This retrieves the role ID from discord.yml.

3. Changed the order of checks in button interaction logic:
   Inside the `onButtonInteraction(@NotNull ButtonInteractionEvent event)` method (line 99), I modified the logic so that it first:
   - Checks if the member object is null.
   - Then verifies if the interacting user has the required role (based on the ID from discord.yml).

_This fixes a bug where users without the proper permission could still click the "Accept" button. Although it would say they lacked permission, the action would still go through issuing the refund and giving items to the player. Now, the interaction is blocked entirely unless the user has the correct role._
