### PR TITLE
Create users in database when join backups are toggled off

### DIFF
--- a/src/main/java/com/artillexstudios/axinventoryrestore/listeners/impl/JoinListener.java
+++ b/src/main/java/com/artillexstudios/axinventoryrestore/listeners/impl/JoinListener.java
@@ -13,11 +13,11 @@ public class JoinListener implements Listener {
 
     @EventHandler
     public void onJoin(@NotNull PlayerJoinEvent event) {
-        if (!CONFIG.getBoolean("enabled-backups.join", true)) return;
         AxInventoryRestore.getThreadedQueue().submit(() -> {
             AxInventoryRestore.getDB().join(event.getPlayer());
             AxInventoryRestore.getDB().fetchRestoreRequests(event.getPlayer().getUniqueId());
         });
+        if (!CONFIG.getBoolean("enabled-backups.join", true)) return;
         AxInventoryRestore.getDB().saveInventory(event.getPlayer(), "JOIN", null);
         BackupLimiter.tryLimit(event.getPlayer().getUniqueId(), "join", "JOIN");
     }


### PR DESCRIPTION
Disabling join backups in the config prevented the plugin from working, since the initial user data was not being saved to the database.
Moving this line resolves the issue.